### PR TITLE
Add docker support

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.CHCR_PAT }}
+          password: ${{ secrets.GHCR_PAT }}
       - name: 'Build:dockerimage'
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -22,6 +22,23 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            efinder2/his_in_one_qis_exam_notification
+            ghcr.io/efinder2/his_in_one_qis_exam_notification
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build and push

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -16,12 +16,6 @@ jobs:
     steps:
       - name: "Build:checkout"
         uses: actions/checkout@v2
-      - name: Login to Github Packages
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }}
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -41,14 +35,17 @@ jobs:
             type=sha
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: 'Build:dockerimage'
-        uses: docker/build-push-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
-          registry: ghcr.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: 'Build:dockerimage'
+        uses: docker/build-push-action@v2
+        with:
           path: ./
           dockerfile: Docker/Dockerfile
           tags: latest
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }}
+          push: true
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -22,7 +22,7 @@ jobs:
           registry: ghcr.io
           username: "efinder2"
           path: ./
-          password: ${{ secrets.PAT }}
+          password: ${{ secrets.CHCR_PAT }}
           dockerfile: Docker/Dockerfile
           tags: latest
       - name: Image digest

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,45 @@
+name: Build and Publish
+
+on:
+  # run it on push to the default repository branch
+  push:
+    branches:
+      - '**'
+jobs:
+  # define job to build and publish docker image
+  build-and-push-docker-image:
+    name: Build Docker image and push to repositories
+    # run only when code is compiling and tests are passing
+    runs-on: ubuntu-latest
+
+    # steps to perform in job
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # setup Docker buld action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Github Packages
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
+
+      - name: Build image and push to Docker Hub and GitHub Container Registry
+        uses: docker/build-push-action@v2
+        with:
+          # relative path to the place where source code with Dockerfile is located
+          context: ./
+          file: Docker/Dockerfile
+          # Note: tags has to be all lower-case
+          tags: |
+            efinder2/his_in_one_qis_exam_notification:latest
+          # build on feature branches, push only on main branch
+          push: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -41,8 +41,6 @@ jobs:
             type=sha
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-        with:
-          dockerfile: Docker/Dockerfile
       - name: 'Build:dockerimage'
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -21,9 +21,9 @@ jobs:
         with:
           registry: ghcr.io
           username: "efinder2"
-          context: ./
+          path: ./
           password: ${{ secrets.PAT }}
-          file: Docker/Dockerfile
+          dockerfile: Docker/Dockerfile
           tags: latest
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -14,32 +14,16 @@ jobs:
 
     # steps to perform in job
     steps:
-      - name: Checkout code
+      - name: "Build:checkout"
         uses: actions/checkout@v2
-
-      # setup Docker buld action
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Github Packages
-        uses: docker/login-action@v1
+      - name: 'Build:dockerimage'
+        uses: docker/build-push-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PAT }}
-
-      - name: Build image and push to Docker Hub and GitHub Container Registry
-        uses: docker/build-push-action@v2
-        with:
-          # relative path to the place where source code with Dockerfile is located
+          username: "efinder2"
           context: ./
+          password: ${{ secrets.PAT }}
           file: Docker/Dockerfile
-          # Note: tags has to be all lower-case
-          tags: |
-            efinder2/his_in_one_qis_exam_notification:latest
-          # build on feature branches, push only on main branch
-          push: ${{ github.ref == 'refs/heads/main' }}
-
+          tags: latest
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -16,11 +16,12 @@ jobs:
     steps:
       - name: "Build:checkout"
         uses: actions/checkout@v2
-      uses: docker/login-action@v1
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.CHCR_PAT }}
+      - name: Login to Github Packages
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.CHCR_PAT }}
       - name: 'Build:dockerimage'
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -12,7 +12,7 @@ jobs:
     # run only when code is compiling and tests are passing
     runs-on: ubuntu-latest
 
-    # steps to perform in job
+    # steps to perform in the job
     steps:
       - name: "Build:checkout"
         uses: actions/checkout@v2

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -22,6 +22,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and push
+        uses: docker/build-push-action@v2
       - name: 'Build:dockerimage'
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -16,13 +16,16 @@ jobs:
     steps:
       - name: "Build:checkout"
         uses: actions/checkout@v2
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.CHCR_PAT }}
       - name: 'Build:dockerimage'
         uses: docker/build-push-action@v1
         with:
           registry: ghcr.io
-          username: "efinder2"
           path: ./
-          password: ${{ secrets.CHCR_PAT }}
           dockerfile: Docker/Dockerfile
           tags: latest
       - name: Image digest

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -29,5 +29,7 @@ jobs:
           path: ./
           dockerfile: Docker/Dockerfile
           tags: latest
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PAT }}
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -41,8 +41,8 @@ jobs:
             type=sha
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Build and push
-        uses: docker/build-push-action@v2
+        with:
+          dockerfile: Docker/Dockerfile
       - name: 'Build:dockerimage'
         uses: docker/build-push-action@v1
         with:

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -6,7 +6,7 @@ VOLUME ["/data"]
 
 RUN mkdir /workingdir
 
-RUN apt-get update && apt-get -y install cron
+RUN apt-get update
 
 COPY configuration.py /workingdir/
 COPY crawl.py /workingdir/

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,31 @@
+# About my dockerfile
+# directive=value
+FROM python:latest
+RUN mkdir /data
+VOLUME ["/data"]
+
+RUN mkdir /workingdir
+
+# Cron stuff from https://stackoverflow.com/questions/37458287/how-to-run-a-cron-job-inside-a-docker-container
+RUN apt-get update && apt-get -y install cron
+COPY Docker/crontab /etc/cron.d/crawl_tab
+RUN chmod 0644 /etc/cron.d/crawl_tab
+RUN crontab /etc/cron.d/crawl_tab
+RUN touch /etc/cron.d/crawl_tab
+
+COPY configuration.py /workingdir/
+COPY crawl.py /workingdir/
+COPY notenliste.py /workingdir/
+COPY notifier.py /workingdir/
+COPY requirements.txt /workingdir/
+COPY test.py /workingdir/
+COPY Docker/run.sh /workingdir/
+
+
+
+
+RUN pip install -r /workingdir/requirements.txt
+
+ENTRYPOINT ["/workingdir/run.sh"]
+
+

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -6,12 +6,7 @@ VOLUME ["/data"]
 
 RUN mkdir /workingdir
 
-# Cron stuff from https://stackoverflow.com/questions/37458287/how-to-run-a-cron-job-inside-a-docker-container
 RUN apt-get update && apt-get -y install cron
-COPY Docker/crontab /etc/cron.d/crawl_tab
-RUN chmod 0644 /etc/cron.d/crawl_tab
-RUN crontab /etc/cron.d/crawl_tab
-RUN touch /etc/cron.d/crawl_tab
 
 COPY configuration.py /workingdir/
 COPY crawl.py /workingdir/

--- a/Docker/crontab
+++ b/Docker/crontab
@@ -1,2 +1,0 @@
-* * * * *   root /workdir/crawl.py >> /var/log/cron.log 2>&1
-# Don't remove the empty line at the end of this file. It is required to run the cron job

--- a/Docker/crontab
+++ b/Docker/crontab
@@ -1,0 +1,2 @@
+* * * * *   root /workdir/crawl.py >> /var/log/cron.log 2>&1
+# Don't remove the empty line at the end of this file. It is required to run the cron job

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+if ! python3 /workingdir/crawl.py --config /data/myHisConfig.cfg; then
+    exit 1
+fi
+
+while python3 /workingdir/crawl.py --config /data/myHisConfig.cfg; do
+  var=$((60 * 60 * 1000));
+  sleep $var
+
+  current_date_time="$(date +%Y%m%d%H%M%S)";
+  echo "$current_date_time";
+done
+
+echo "crawl missed"
+exit 1

--- a/README.md
+++ b/README.md
@@ -69,3 +69,10 @@ Das Resultat liegt danach im Pfad `dist/crawl`.
 
 Optional kann die Installation der Abhängigkeiten und Bauen der ausführbaren Datei durch Aufruf von `linux_build_env/package.sh` angestoßen werden.
 Beachte, dass dabei die Abhängigkeiten direkt durch deinen Benutzer in deinem System installiert werden. Python muss bereits vorhanden sein
+
+## Starten mit Docker
+Die Anwendung steht auch als docker container zur Verfügung. Dieserkann über die Kommandozeile installiert werden.
+> $ docker pull ghcr.io/efinder2/hisinone-qis-exam-notification:latest
+
+Der Container führt den Job jede Stunde aus. Für die Konfiguration wird das Volumen `/data` benötigt. Hierin wird die Konfigurationsdatei `myHisConfig.cfg` abgelegt. Diese kann wie oben beschrieben angepasst werden.
+Es ist empfehlenswert den Container zusammen mit dem watchtower image auszuführen, sodass man immer den aktuellen Stand hat. Dis ist sinnvoll, da das Programm für Änderungen am iCMS (horstl) angepasst werden kann.

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ Optional kann die Installation der Abhängigkeiten und Bauen der ausführbaren D
 Beachte, dass dabei die Abhängigkeiten direkt durch deinen Benutzer in deinem System installiert werden. Python muss bereits vorhanden sein
 
 ## Starten mit Docker
-Die Anwendung steht auch als docker container zur Verfügung. Dieserkann über die Kommandozeile installiert werden.
-> $ docker pull ghcr.io/efinder2/hisinone-qis-exam-notification:latest
+Die Anwendung steht auch als docker container zur Verfügung. Dieser kann über die Kommandozeile installiert werden. Hierzu ist ein Login zur github
+
+> docker pull /efinder2/hisinone-qis-exam-notification:latest
 
 Der Container führt den Job jede Stunde aus. Für die Konfiguration wird das Volumen `/data` benötigt. Hierin wird die Konfigurationsdatei `myHisConfig.cfg` abgelegt. Diese kann wie oben beschrieben angepasst werden.
 Es ist empfehlenswert den Container zusammen mit dem watchtower image auszuführen, sodass man immer den aktuellen Stand hat. Dis ist sinnvoll, da das Programm für Änderungen am iCMS (horstl) angepasst werden kann.


### PR DESCRIPTION
Creates Docker support. The image is built via githubactions and added to the github container registry. For this github needs a personal access token. It should be stored in a repository secret named `GHCR_PAT`. Following permissions are needed:
* repo
* read:packages
* write:packages
I don't know how to change the URL of the README by fork automated. I'm open for ideas.

I know the while true in the run.sh isn't ideal but it works 🙈 